### PR TITLE
change access method to http for puppet-consul

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/nanliu/puppet-staging.git
 [submodule "modules/consul"]
 	path = modules/consul
-	url = git@github.com:jayjanssen/puppet-consul.git
+	url = https://github.com/jayjanssen/puppet-consul.git
 [submodule "modules/bind"]
 	path = modules/bind
 	url = https://github.com/thias/puppet-bind.git


### PR DESCRIPTION
Submodule might fail with permission denied for non-authenticated users otherwise.