### PR TITLE
if a hostname contains a dash, then the mysql statement did not work,…

### DIFF
--- a/modules/percona/manifests/remove_anonymous_user.pp
+++ b/modules/percona/manifests/remove_anonymous_user.pp
@@ -2,7 +2,7 @@ class percona::remove_anonymous_user {
 
 	exec {
 		'remove_anonymous_user':
-			command	=> "mysql -Ne \"select concat('DROP USER \\'', user, '\\'@', host, ';') from mysql.user where user='';\" | mysql ",
+			command	=> "mysql -Ne 'select concat(\"DROP USER \\\"\", user, \"\\\"@`\", host, \"`;\") from mysql.user where user=\"\";' | mysql",
 			cwd 	=> "/root",
 			path 	=> ['/usr/bin', '/bin'],
 			require => [ Service['mysql'] ];


### PR DESCRIPTION
… we need to escape it, and escape a lot of other shizzle because we run ruby shizzle to execute bash shizzle to run a mysql query manizzle